### PR TITLE
docs: add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+## Git workflow
+
+Always work on a branch and open a pull request — never push directly to `main`.
+
+```bash
+git checkout -b your-branch-name
+git add -A && git commit -m "your message"
+git push -u origin HEAD
+gh pr create
+```


### PR DESCRIPTION
## Summary

- Add `CONTRIBUTING.md` with the repo's git workflow guideline (always branch + PR, never push directly to `main`)
- Replaces the Cursor-specific `.cursor/rules/git-workflow.mdc` approach with something generic and repo-agnostic

## Test plan

- [ ] Check `CONTRIBUTING.md` renders correctly on GitHub

Made with [Cursor](https://cursor.com)