### PR TITLE
feat: use hibikiji.png as identity note on homepage

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -195,95 +195,82 @@
   pointer-events: none;
 }
 
-/* ---------- Case header note ---------- */
-.case {
-  position: relative;
-  display: flex;
-  gap: 1.6rem;
-  align-items: center;
-  flex-wrap: wrap;
-  max-width: 720px;
-  margin: 0 auto 3.5rem;
-  padding: 1.6rem 1.8rem;
-  background: var(--note-bg);
-  color: var(--note-text);
-  border-radius: 3px;
-  box-shadow: var(--note-shadow);
+/* ---------- Identity note (hibikiji.png) ---------- */
+.note--identity {
+  --pin: var(--h-sakura);
+  grid-column: span 2;
+  padding: 0;
+  min-height: 240px;
+  max-height: 280px;
+  overflow: hidden;
+  background: #0a0a14;
+  background-image: none;
+}
+.note--identity:nth-child(1) {
   transform: rotate(-1.2deg);
+  margin-top: 0;
 }
-/* washi tape holding the header note */
-.case::before {
-  content: "";
-  position: absolute;
-  top: -14px;
-  left: 50%;
-  width: 130px;
-  height: 30px;
-  transform: translateX(-50%) rotate(-2deg);
-  background: var(--tape);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+.note--identity:hover {
+  transform: rotate(0deg) translateY(-6px) scale(1.02);
 }
-
-.case__polaroid {
-  background: #fff;
-  padding: 8px 8px 26px;
-  border-radius: 2px;
-  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.3);
-  transform: rotate(-3deg);
-  position: relative;
-}
-.case__polaroid img {
+.note__img {
   display: block;
-  width: 120px;
-  height: 84px;
+  width: 100%;
+  height: 280px;
   object-fit: cover;
-  border-radius: 1px;
+  object-position: center 20%;
 }
-.case__cap {
+.note__overlay {
   position: absolute;
-  bottom: 4px;
-  left: 0;
-  right: 0;
-  text-align: center;
-  font-family: var(--h-hand);
-  font-size: 1.15rem;
-  color: #444;
+  inset: auto 0 0;
+  padding: 2.2rem 1.5rem 1.3rem;
+  background: linear-gradient(
+    to top,
+    rgba(0,0,0,0.92) 0%,
+    rgba(0,0,0,0.72) 40%,
+    rgba(0,0,0,0.2) 70%,
+    transparent 100%
+  );
+  color: #fff;
 }
-
-.case__body {
-  flex: 1 1 300px;
-}
-.case__kicker {
+.note__kicker {
   font-family: var(--h-display);
+  font-size: 0.8rem;
   font-weight: 700;
-  color: var(--h-iris);
-  font-size: 0.95rem;
+  color: var(--h-sakura);
+  display: block;
+  margin-bottom: 0.1rem;
+  text-shadow: 0 1px 4px rgba(0,0,0,0.8);
 }
-.case__title {
+.note__title {
   font-family: var(--h-hand) !important;
   font-weight: 700;
-  font-size: clamp(2.4rem, 5.5vw, 3.4rem) !important;
+  font-size: clamp(1.9rem, 4vw, 2.6rem) !important;
   line-height: 1 !important;
-  margin: 0.1rem 0 0.5rem !important;
-  color: var(--note-text);
+  margin: 0 0 0.3rem !important;
+  color: #fff;
+  text-shadow: 0 2px 8px rgba(0,0,0,0.8);
 }
-.case__sub {
-  color: var(--note-muted);
-  font-size: 0.92rem;
-  line-height: 1.55;
-  margin: 0 0 0.9rem;
+.note__tagline {
+  color: rgba(255,255,255,0.82);
+  font-size: 0.85rem;
+  line-height: 1.45;
+  margin: 0 0 0.65rem;
+  max-width: 52ch;
+  text-shadow: 0 1px 4px rgba(0,0,0,0.7);
 }
-.case__link {
+.note__cta {
   font-family: var(--h-hand);
-  font-size: 1.3rem;
+  font-size: 1.2rem;
   font-weight: 600;
-  color: var(--h-iris) !important;
-  text-decoration: none;
-  border-bottom: 2px dashed color-mix(in srgb, var(--h-iris) 45%, transparent);
+  color: var(--h-sakura);
+  border-bottom: 2px dashed rgba(255, 111, 165, 0.5);
+  display: inline-block;
+  transition: color 0.18s;
 }
-.case__link:hover {
-  color: var(--h-sakura) !important;
-  border-bottom-color: var(--h-sakura);
+.note--identity:hover .note__cta {
+  color: #fff;
+  border-bottom-color: rgba(255,255,255,0.5);
 }
 
 /* red rubber stamp */
@@ -462,6 +449,8 @@
   .board { border-width: 8px; }
   .note { min-height: 150px; }
   .note:nth-child(n) { margin-top: 0; }
+  .note--identity { grid-column: span 1; }
+  .note__img { max-height: 180px; }
 }
 
 /* ============================================================

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -3,30 +3,23 @@
 {% block content %}
 <div class="board">
 
-  <!-- ---------- Case header (pinned) ---------- -->
-  <header class="case">
-    <div class="case__polaroid">
-      <img src="{{ base_url }}/assets/favicon.png" alt="Hibikiji">
-      <span class="case__cap">ひびき</span>
-    </div>
-    <div class="case__body">
-      <span class="case__kicker">こんにちは、</span>
-      <h1 class="case__title">I build things<br>&amp; write about all of it.</h1>
-      <p class="case__sub">
-        Platform engineer by day, weeb by night. Pinned to this board: my code,
-        travels, cooking experiments, and whatever hobby has hijacked my brain
-        this month.
-      </p>
-      <a class="case__link" href="{{ base_url }}/blog/">flip through the case file →</a>
-    </div>
-    <span class="stamp">case&nbsp;#001<br><small>personal archive</small></span>
-  </header>
-
   <!-- ---------- Board label ---------- -->
   <div class="board__label">topics on the board</div>
 
   <!-- ---------- Pinned notes ---------- -->
   <div class="notes">
+
+    <!-- Identity note — hibikiji.png -->
+    <a class="note note--identity" href="{{ base_url }}/blog/">
+      <img class="note__img" src="{{ base_url }}/assets/hibikiji.png" alt="Hibikiji">
+      <div class="note__overlay">
+        <span class="note__kicker">日々記事</span>
+        <h1 class="note__title">Hibikiji</h1>
+        <p class="note__tagline">Sometimes I write to leave my marks on this never-ending expanding cyberspace.</p>
+        <span class="note__cta">browse →</span>
+      </div>
+      <span class="stamp">case&nbsp;#001<br><small>personal archive</small></span>
+    </a>
 
     <a class="note note--platform" href="{{ base_url }}/blog/category/platform-engineering/">
       <span class="note__no">01</span>


### PR DESCRIPTION
## Summary

- Replace the separate case-header section with a full-bleed image note using `docs/assets/hibikiji.png` as the first pinned note on the board
- Dark gradient overlay at the bottom of the image keeps the title, tagline, and `browse →` link readable
- CASE #001 stamp and sakura push-pin carried over
- Removed all old `.case*` CSS (~89 lines); added focused `.note--identity` styles

## Preview

Works in both light (cork board) and dark (felt board) modes — the dark overlay is always dark regardless of theme, so text stays legible.

Made with [Cursor](https://cursor.com)